### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ poetry run invoke train
 * [Specification document](https://github.com/JuusoSaavalainen/TiraLAB/blob/main/documentation/specification.md)
 * [Test document](https://github.com/JuusoSaavalainen/TiraLAB-Neural-network-with-numpy/blob/main/documentation/testdocumentation.md)
 
-### Weekly reaports
+### Weekly raports
 * [Week 1](https://github.com/JuusoSaavalainen/TiraLAB/blob/main/documentation/weeklyrecap1.md)
 * [Week 2](https://github.com/JuusoSaavalainen/TiraLAB-Neural-network-with-numpy/blob/main/documentation/weeklyrecap2.md)
 * [Week 3](https://github.com/JuusoSaavalainen/TiraLAB-Neural-network-with-numpy/blob/main/documentation/weeklyrecap3.md)


### PR DESCRIPTION
I noticed a small typo in your README.md file. The word "reaports" should be "raports". I have made the correction in this pull request.